### PR TITLE
Factory: Fix run-time exception on "RASPBIAN STRETCH LITE"

### DIFF
--- a/lib/Factory.js
+++ b/lib/Factory.js
@@ -79,6 +79,7 @@ Factory.prototype._create_control = function(value) {
 };
 
 Factory.prototype._map_list = function(list, func) {
+    "use strict";
     var output_list = {};
 
     Object.keys(list).forEach( function(entry) {


### PR DESCRIPTION
Without "use strict" the command "lox-mqtt-gateway" throws exception:

  /usr/local/lib/node_modules/node-lox-mqtt-gateway/node_modules/node-lox-structure-file/lib/Factory.js:85
          let output_item = func.call(this, entry, list[entry]);
          ^^^

  SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
      at exports.runInThisContext (vm.js:53:16)
      at Module._compile (module.js:373:25)
      at Object.Module._extensions..js (module.js:416:10)
      at Module.load (module.js:343:32)
      at Function.Module._load (module.js:300:12)
      at Module.require (module.js:353:17)
      at require (internal/module.js:12:17)
      at Object.<anonymous> (/usr/local/lib/node_modules/node-lox-mqtt-gateway/lib/index.js:7:18)
      at Module._compile (module.js:409:26)
      at Object.Module._extensions..js (module.js:416:10)